### PR TITLE
using an adress that was not allocated fix

### DIFF
--- a/netpgp/lib/keyring.c
+++ b/netpgp/lib/keyring.c
@@ -865,7 +865,7 @@ str2keyid(const char *userid, uint8_t *keyid, size_t len)
 	size_t			 j;
 	int			 i;
 
-	for (i = 0, j = 0 ; j < len && userid[i] && userid[i + 1] ; i += 2, j++) {
+	for (i = 0, j = 0 ; j < len - 1 && userid[i] && userid[i + 1] ; i += 2, j++) {
 		if ((hi = strchr(uppers, userid[i])) == NULL) {
 			if ((hi = strchr(lowers, userid[i])) == NULL) {
 				break;


### PR DESCRIPTION
Pull request according to my issue https://github.com/upnext/unnetpgp/issues/20
Changes in issue and pull request are different, but have the same result. Dont know, what the meaning of parameter `len` in `str2keyid(const char *userid, uint8_t *keyid, size_t len)`. Is it the length of the `keyid` allocated memory or the length of the binary `keyid`.  I choose first.
